### PR TITLE
docs(libra): update switch command docs for --track

### DIFF
--- a/contents/docs/libra/command/switch/index.mdx
+++ b/contents/docs/libra/command/switch/index.mdx
@@ -17,7 +17,9 @@ Switch to a specified branch. The working tree and the index are updated to matc
 
 **Remote branches**
 
-Libra does not automatically create a local tracking branch when you switch to a remote branch. If you want to create a local branch that tracks a remote branch, use `--track`.
+By default, Libra does not create a local tracking branch when you switch to a remote branch. Use `--track` to create one.
+
+Make sure the remote-tracking ref exists (run `libra fetch <remote>` first).
 
 ```shell
 libra fetch origin
@@ -51,7 +53,7 @@ libra switch new-branch
     Switch to a commit.
 
 -   `--track`
-    Create a local tracking branch when switching to a remote branch.
+    Create a local branch from a remote-tracking branch and set upstream.
 
 <Note type="note" title="Note">
 The options of the switch command are same as git, but the behavior is different.

--- a/contents/docs/libra/command/switch/index.mdx
+++ b/contents/docs/libra/command/switch/index.mdx
@@ -15,9 +15,25 @@ libra switch [OPTIONS] [BRANCH]
 
 Switch to a specified branch. The working tree and the index are updated to match the branch. You should make sure the working tree is clean before switching branches. Otherwise, the operation will be aborted.
 
-**Handle with remote branches**
+**Remote branches**
 
-If you want to switch to a remote branch, you need to create a new branch based on the remote branch and switch to it.
+Libra does not automatically create a local tracking branch when you switch to a remote branch. If you want to create a local branch that tracks a remote branch, use `--track`.
+
+```shell
+libra fetch origin
+libra switch --track origin/new-branch
+```
+
+This creates a local branch `new-branch`, sets its upstream to `origin/new-branch`, and switches to it.
+
+If the remote is `origin`, you can omit it:
+
+```shell
+libra fetch origin
+libra switch --track new-branch
+```
+
+If you prefer to do it manually, you can still create a local branch from a remote branch and switch to it.
 
 ```shell
 libra fetch origin
@@ -34,10 +50,13 @@ libra switch new-branch
 -   `-d`, `--detach`
     Switch to a commit.
 
+-   `--track`
+    Create a local tracking branch when switching to a remote branch.
+
 <Note type="note" title="Note">
 The options of the switch command are same as git, but the behavior is different.
 
-1. Git has a feature that, when you switch to a branch didn't exist locally but exists remotely, it will create a new branch locally and track the remote branch. Libra doesn't support this feature yet.
+1. Git can create a local tracking branch when you switch to a branch that exists remotely. In Libra, you can use `libra switch --track <remote>/<branch>` to get a similar behavior.
 
 2. Git didn't require a clean index and working tree before switching branches, but libra does.
 


### PR DESCRIPTION
此 PR 更新 libra switch 命令文档，补充并完善 --track 参数的说明与使用示例，明确在切换远程分支时如何创建本地分支并设置 upstream，同时补充必要的前置操作提示。